### PR TITLE
fix bug where 'apply' always recreates the environment

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -48,6 +48,10 @@ resource "aws_security_group" "allow_osb" {
   name        = "${terraform.workspace}-allow-osb"
   description = "Allow ES/OS/OSB inbound traffic and all outbound traffic"
   vpc_id      = aws_vpc.vpc.id
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_vpc_security_group_ingress_rule" "allow_ssh" {

--- a/infra/modules/elasticsearch/main.tf
+++ b/infra/modules/elasticsearch/main.tf
@@ -1,8 +1,8 @@
 resource "aws_instance" "target-cluster" {
-  ami             = var.ami_id
-  instance_type   = var.instance_type
-  key_name        = var.ssh_key_name
-  security_groups = var.security_groups
+  ami                    = var.ami_id
+  instance_type          = var.instance_type
+  key_name               = var.ssh_key_name
+  vpc_security_group_ids = var.security_groups
 
   associate_public_ip_address = true
 
@@ -17,6 +17,7 @@ resource "aws_instance" "target-cluster" {
       es_snapshot_secret_key = var.snapshot_user_aws_secret_access_key,
     }
   )
+  user_data_replace_on_change = true
 
   private_dns_name_options {
     hostname_type = "resource-name"
@@ -30,10 +31,10 @@ data "aws_eip" "load-gen-eip" {
 }
 
 resource "aws_instance" "load-generation" {
-  ami             = var.ami_id
-  instance_type   = var.instance_type
-  key_name        = var.ssh_key_name
-  security_groups = var.security_groups
+  ami                    = var.ami_id
+  instance_type          = var.instance_type
+  key_name               = var.ssh_key_name
+  vpc_security_group_ids = var.security_groups
 
   # Temporarily assign public IP before EIP so that provisioner can connect to instance
   # NOTE: self.public_ip will be outdated after the aws_eip_association
@@ -73,6 +74,7 @@ resource "aws_instance" "load-generation" {
       ),
     }
   )
+  user_data_replace_on_change = true
 
   provisioner "remote-exec" {
     inline = [

--- a/infra/modules/opensearch/main.tf
+++ b/infra/modules/opensearch/main.tf
@@ -1,8 +1,8 @@
 resource "aws_instance" "target-cluster" {
-  ami             = var.ami_id
-  instance_type   = var.instance_type
-  key_name        = var.ssh_key_name
-  security_groups = var.security_groups
+  ami                    = var.ami_id
+  instance_type          = var.instance_type
+  key_name               = var.ssh_key_name
+  vpc_security_group_ids = var.security_groups
 
   associate_public_ip_address = true
 
@@ -15,6 +15,7 @@ resource "aws_instance" "target-cluster" {
       os_version        = var.os_version,
     }
   )
+  user_data_replace_on_change = true
 
   private_dns_name_options {
     hostname_type = "resource-name"
@@ -28,10 +29,10 @@ data "aws_eip" "load-gen-eip" {
 }
 
 resource "aws_instance" "load-generation" {
-  ami             = var.ami_id
-  instance_type   = var.instance_type
-  key_name        = var.ssh_key_name
-  security_groups = var.security_groups
+  ami                    = var.ami_id
+  instance_type          = var.instance_type
+  key_name               = var.ssh_key_name
+  vpc_security_group_ids = var.security_groups
 
   # Temporarily assign public IP before EIP so that provisioner can connect to instance
   # NOTE: self.public_ip will be outdated after the aws_eip_association
@@ -63,6 +64,7 @@ resource "aws_instance" "load-generation" {
       ),
     }
   )
+  user_data_replace_on_change = true
 
   provisioner "remote-exec" {
     inline = [


### PR DESCRIPTION
`terraform apply` was always re-creating the whole environment even when no changes were done. This was caused by the use of `security_groups` vs `vpc_security_group_ids`.

Closes #23 