### PR TITLE
Allow different regions than the prefix list's region

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -23,6 +23,18 @@ provider "aws" {
   }
 }
 
+provider "aws" {
+  region = "us-east-1"
+  alias  = "prefix_list_region"
+
+  default_tags {
+    tags = {
+      Workspace = terraform.workspace
+      Service   = "OSB"
+    }
+  }
+}
+
 resource "aws_key_pair" "ssh_key" {
   key_name   = "${terraform.workspace}-ssh-key"
   public_key = file(var.ssh_pub_key)
@@ -98,7 +110,8 @@ resource "aws_route_table_association" "subnet-association" {
 }
 
 data "aws_ec2_managed_prefix_list" "prefix-list" {
-  id = var.prefix_list_id
+  provider = aws.prefix_list_region
+  id       = var.prefix_list_id
 }
 
 data "aws_ami" "ubuntu_ami" {
@@ -148,6 +161,11 @@ module "es-cluster" {
   snapshot_user_aws_secret_access_key = var.snapshot_user_aws_secret_access_key
   workload_params                     = var.workload_params
 
+  providers = {
+    aws                    = aws
+    aws.prefix_list_region = aws.prefix_list_region
+  }
+
   tags = {
     Name = "target-cluster"
   }
@@ -175,6 +193,11 @@ module "os-cluster" {
   snapshot_user_aws_access_key_id     = var.snapshot_user_aws_access_key_id
   snapshot_user_aws_secret_access_key = var.snapshot_user_aws_secret_access_key
   workload_params                     = var.workload_params
+
+  providers = {
+    aws                    = aws
+    aws.prefix_list_region = aws.prefix_list_region
+  }
 
   tags = {
     Name = "target-cluster"

--- a/infra/modules/elasticsearch/main.tf
+++ b/infra/modules/elasticsearch/main.tf
@@ -1,3 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
+      version               = "5.65.0"
+      configuration_aliases = [aws.prefix_list_region]
+    }
+  }
+}
+
 resource "aws_instance" "target-cluster" {
   ami                    = var.ami_id
   instance_type          = var.instance_type
@@ -110,6 +120,7 @@ resource "aws_instance" "load-generation" {
 }
 
 resource "aws_ec2_managed_prefix_list_entry" "prefix-list-entry-load-gen" {
+  provider       = aws.prefix_list_region
   cidr           = "${aws_instance.load-generation.public_ip}/32"
   description    = terraform.workspace
   prefix_list_id = var.prefix_list_id

--- a/infra/modules/opensearch/main.tf
+++ b/infra/modules/opensearch/main.tf
@@ -1,3 +1,13 @@
+terraform {
+  required_providers {
+    aws = {
+      source                = "hashicorp/aws"
+      version               = "5.65.0"
+      configuration_aliases = [aws.prefix_list_region]
+    }
+  }
+}
+
 resource "aws_instance" "target-cluster" {
   ami                    = var.ami_id
   instance_type          = var.instance_type
@@ -109,6 +119,7 @@ resource "aws_instance" "load-generation" {
 }
 
 resource "aws_ec2_managed_prefix_list_entry" "prefix-list-entry-load-gen" {
+  provider       = aws.prefix_list_region
   cidr           = "${aws_instance.load-generation.public_ip}/32"
   description    = terraform.workspace
   prefix_list_id = var.prefix_list_id


### PR DESCRIPTION
This fixes a problem where one could only deploy to the same region as the prefix list.