### PR TITLE
Existing scripts deal with JSON result files

### DIFF
--- a/infra/scripts/get_results.sh
+++ b/infra/scripts/get_results.sh
@@ -5,5 +5,17 @@ if [ $# -ne 1 ]; then
     exit 1
 fi
 OUTPUT_DIR=$1
-REMOTE_PATH="/mnt/test_executions/*"
-rsync --ignore-existing "ubuntu@$(terraform output -raw load-generation-ip):$REMOTE_PATH" "$OUTPUT_DIR"
+
+mkdir -p "$OUTPUT_DIR"
+
+REMOTE_PATH="/mnt/.benchmark/benchmarks/test_executions/cluster*"
+TMP_DIR="$(mktemp -d)"
+rsync -r --ignore-existing "ubuntu@$(terraform output -raw load-generation-ip):$REMOTE_PATH" "$TMP_DIR"
+
+# Move all files from the temporary directory to the output directory but rename
+# them to "res-0", "res-1", etc.
+for i in $(seq 0 4); do
+    mv $TMP_DIR/cluster*-$i/test_execution.json "$OUTPUT_DIR/res-$i.json"
+done
+
+rm -rf "$TMP_DIR"


### PR DESCRIPTION
the files saved in /mnt/test_execution are the markdown tables, however the scripts we have for averaging results deal with the json files.