### PR TITLE
Remove warmup tag

### DIFF
--- a/infra/results_metadata.md
+++ b/infra/results_metadata.md
@@ -20,15 +20,14 @@ User tags are custom fields added to enrich the metadata. They are recorded in d
 | shard-count | Number of primary shards in the cluster index |
 | replica-count | Number of replica shards for each primary shard  |
 | run | Zero-indexed number for a run in a run group |
-| run-type | Type of run. Options are `official`, `dev`, `ingest`, and `warmup` |
+| run-type | Type of run. Options are `official`, `dev`, and `ingest` |
 | snapshot-s3-bucket | S3 bucket storing the snapshot |
 | snapshot-base-path | Snapshot base path in S3 bucket. Format: "cluster_type/cluster_version/workload/snapshot_version" |
 
 - Explanation of `run-type` options:
-    - `official`: Runs that should be included in reports
+    - `official`: Runs that should be included in reports (includes warmup runs)
     - `dev`: Runs executed during development. Can be ignored
     - `ingest`: Data ingestion runs. Can be ignored
-    - `warmup`: Warm up runs. Can be ignored
 
 ## Built-in Fields
 Built-in fields are created by OpenSearch Benchmark, but may have user-controlled input. This section describes key built-in fields for metadata.

--- a/infra/scripts/benchmark.sh
+++ b/infra/scripts/benchmark.sh
@@ -44,6 +44,7 @@ REPLICA_COUNT="$(curl -m 5 -s --insecure --user "$CLUSTER_USER:$CLUSTER_PASSWORD
 # assumes same machine for cluster
 GROUP_USER_TAGS="run-group:$RUN_GROUP_ID,engine-type:$ENGINE_TYPE,arch:$(arch),instance-type:$INSTANCE_TYPE,aws-user-id:$AWS_USERID,aws-loadgen-instance-id:$AWS_LOADGEN_INSTANCE_ID"
 GROUP_USER_TAGS+=",cluster-version:$CLUSTER_VERSION,workload-distribution-version:$DISTRIBUTION_VERSION,shard-count:$SHARD_COUNT,replica-count:$REPLICA_COUNT"
+GROUP_USER_TAGS+=",run-type:$RUN_TYPE"
 
 REPOSITORY_SET=$(curl -sku "$CLUSTER_USER:$CLUSTER_PASSWORD" -X GET "$CLUSTER_HOST/_cluster/state/metadata" | jq --raw-output '.metadata | has("repositories") and .repositories != null')
 if [ "$REPOSITORY_SET" == "true" ]; then
@@ -70,12 +71,6 @@ do
         TEST_EXECUTION_ID="cluster-$RUN_GROUP_ID-$i"
         RESULTS_FILE="$EXECUTION_DIR/$TEST_EXECUTION_ID"
         USER_TAGS="$GROUP_USER_TAGS,run:$i"
-        # tag first run as a warmup
-        if [[ $i -eq 0 ]]; then
-            USER_TAGS+=",run-type:warmup"
-        else
-            USER_TAGS+=",run-type:$RUN_TYPE"
-        fi
         benchmark_single \
             "$WORKLOAD" \
             "$CLUSTER_HOST" \

--- a/infra/scripts/benchmark_single.sh
+++ b/infra/scripts/benchmark_single.sh
@@ -45,6 +45,7 @@ REPLICA_COUNT="$(curl -m 5 -s --insecure --user "$CLUSTER_USER:$CLUSTER_PASSWORD
 # assumes same machine for cluster
 GROUP_USER_TAGS="run-group:$RUN_GROUP_ID,engine-type:$ENGINE_TYPE,arch:$(arch),instance-type:$INSTANCE_TYPE,aws-user-id:$AWS_USERID,aws-loadgen-instance-id:$AWS_LOADGEN_INSTANCE_ID"
 GROUP_USER_TAGS+=",cluster-version:$CLUSTER_VERSION,workload-distribution-version:$DISTRIBUTION_VERSION,shard-count:$SHARD_COUNT,replica-count:$REPLICA_COUNT"
+GROUP_USER_TAGS+=",run-type:$RUN_TYPE"
 
 set -x
 
@@ -57,12 +58,6 @@ check_params "$CLUSTER_USER" "$CLUSTER_PASSWORD" "$CLUSTER_HOST" "$WORKLOAD" "$I
 TEST_EXECUTION_ID="cluster-$RUN_GROUP_ID-$RUN_ID"
 RESULTS_FILE="$EXECUTION_DIR/$TEST_EXECUTION_ID"
 USER_TAGS="$GROUP_USER_TAGS,run:$RUN_ID"
-# tag first run as a warmup
-if [[ $RUN_ID -eq 0 ]]; then
-    USER_TAGS+=",run-type:warmup"
-else
-    USER_TAGS+=",run-type:$RUN_TYPE"
-fi
 benchmark_single \
     "$WORKLOAD" \
     "$CLUSTER_HOST" \


### PR DESCRIPTION
Remove warmup tag so that warmup tags are marked official and can be excluded by the run number.