### PR TITLE
Fix getting index settings when the name doesn't correspond to the workload

### DIFF
--- a/infra/scripts/benchmark.sh
+++ b/infra/scripts/benchmark.sh
@@ -40,8 +40,8 @@ CLIENT_OPTIONS=$(join_by , "basic_auth_user:$CLUSTER_USER,basic_auth_password:$C
 RUN_GROUP_ID="$(date '+%Y_%m_%d_%H_%M_%S')"
 AWS_LOADGEN_INSTANCE_ID="$(curl -m 5 -s http://169.254.169.254/latest/meta-data/instance-id)"
 
-SHARD_COUNT="$(curl -m 5 -s --insecure --user "$CLUSTER_USER:$CLUSTER_PASSWORD" --request GET "$CLUSTER_HOST/$INDEX_NAME/_settings" | jq --raw-output '."$INDEX_NAME".settings.index.number_of_shards')"
-REPLICA_COUNT="$(curl -m 5 -s --insecure --user "$CLUSTER_USER:$CLUSTER_PASSWORD" --request GET "$CLUSTER_HOST/$INDEX_NAME/_settings" | jq --raw-output '."$INDEX_NAME".settings.index.number_of_replicas')"
+SHARD_COUNT="$(curl -m 5 -s --insecure --user "$CLUSTER_USER:$CLUSTER_PASSWORD" --request GET "$CLUSTER_HOST/$INDEX_NAME/_settings" | jq --raw-output ".\"$INDEX_NAME\".settings.index.number_of_shards")"
+REPLICA_COUNT="$(curl -m 5 -s --insecure --user "$CLUSTER_USER:$CLUSTER_PASSWORD" --request GET "$CLUSTER_HOST/$INDEX_NAME/_settings" | jq --raw-output ".\"$INDEX_NAME\".settings.index.number_of_replicas")"
 
 if [ -z "$SHARD_COUNT" ] || [ "$SHARD_COUNT" == "null" ]; then
     echo "Failed to retrieve the shard count"

--- a/infra/scripts/benchmark_single.sh
+++ b/infra/scripts/benchmark_single.sh
@@ -41,8 +41,8 @@ CLIENT_OPTIONS=$(join_by , "basic_auth_user:$CLUSTER_USER,basic_auth_password:$C
 RUN_GROUP_ID="$${RUN_GROUP_ID:-$(date '+%Y_%m_%d_%H_%M_%S')}"
 AWS_LOADGEN_INSTANCE_ID="$(curl -m 5 -s http://169.254.169.254/latest/meta-data/instance-id)"
 
-SHARD_COUNT="$(curl -m 5 -s --insecure --user "$CLUSTER_USER:$CLUSTER_PASSWORD" --request GET "$CLUSTER_HOST/$INDEX_NAME/_settings" | jq --raw-output '."$INDEX_NAME".settings.index.number_of_shards')"
-REPLICA_COUNT="$(curl -m 5 -s --insecure --user "$CLUSTER_USER:$CLUSTER_PASSWORD" --request GET "$CLUSTER_HOST/$INDEX_NAME/_settings" | jq --raw-output '."$INDEX_NAME".settings.index.number_of_replicas')"
+SHARD_COUNT="$(curl -m 5 -s --insecure --user "$CLUSTER_USER:$CLUSTER_PASSWORD" --request GET "$CLUSTER_HOST/$INDEX_NAME/_settings" | jq --raw-output ".\"$INDEX_NAME\".settings.index.number_of_shards")"
+REPLICA_COUNT="$(curl -m 5 -s --insecure --user "$CLUSTER_USER:$CLUSTER_PASSWORD" --request GET "$CLUSTER_HOST/$INDEX_NAME/_settings" | jq --raw-output ".\"$INDEX_NAME\".settings.index.number_of_replicas")"
 
 if [ -z "$SHARD_COUNT" ] || [ "$SHARD_COUNT" == "null" ]; then
     echo "Failed to retrieve the shard count"


### PR DESCRIPTION
- Use the index name not the workload name to get the index settings. For example in the case of the workload `noaa`, the index name is actually `weather-data-2016`.

- Change the quoting so that `jq` doesn't interpret a `-` in the index name as a special character.

- Fail if we cannot get the replica or shard count out of the index settings