### PR TITLE
Tag the target-cluster CPU type

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -215,7 +215,7 @@ jobs:
         run: |
             ssh $SSH_OPTIONS \
               -t ubuntu@$(terraform output -raw load-generation-ip) -- \
-              "set -x; bash -ixc \"FORCE_INGESTION=$FORCE_INGESTION EXTRA_CLIENT_OPTIONS=timeout:240 bash -x /ingest.sh;\""
+              "set -x; bash -ixc \"FORCE_INGESTION=$FORCE_INGESTION EXTRA_CLIENT_OPTIONS=timeout:240 bash -x /mnt/ingest.sh;\""
         env:
             FORCE_INGESTION: ${{ inputs.force_snapshot && 'true' || '' }}
 
@@ -225,7 +225,7 @@ jobs:
         run: |
             ssh $SSH_OPTIONS \
               -t ubuntu@$(terraform output -raw load-generation-ip) -- \
-              "set -x; bash -ixc 'bash -x /restore_snapshot.sh;'"
+              "set -x; bash -ixc 'bash -x /mnt/restore_snapshot.sh;'"
       
 
   run-osb:
@@ -284,7 +284,7 @@ jobs:
         run: |
             ssh $SSH_OPTIONS \
               -t ubuntu@$(terraform output -raw load-generation-ip) -- \
-              "set -x; bash -ixc \"EXTRA_CLIENT_OPTIONS=timeout:240 RUN_GROUP_ID=$RUN_GROUP_ID bash -x /benchmark_single.sh $BENCHMARK_TYPE $RUN_ID;\""
+              "set -x; bash -ixc \"EXTRA_CLIENT_OPTIONS=timeout:240 RUN_GROUP_ID=$RUN_GROUP_ID bash -x /mnt/benchmark_single.sh $BENCHMARK_TYPE $RUN_ID;\""
         env:
             BENCHMARK_TYPE: ${{ inputs.benchmark_type }}
             RUN_ID: ${{ matrix.run_id }}

--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -44,6 +44,25 @@ provider "registry.terraform.io/hashicorp/external" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.5.2"
+  hashes = [
+    "h1:IyFbOIO6mhikFNL/2h1iZJ6kyN3U00jgkpCLUCThAfE=",
+    "zh:136299545178ce281c56f36965bf91c35407c11897f7082b3b983d86cb79b511",
+    "zh:3b4486858aa9cb8163378722b642c57c529b6c64bfbfc9461d940a84cd66ebea",
+    "zh:4855ee628ead847741aa4f4fc9bed50cfdbf197f2912775dd9fe7bc43fa077c0",
+    "zh:4b8cd2583d1edcac4011caafe8afb7a95e8110a607a1d5fb87d921178074a69b",
+    "zh:52084ddaff8c8cd3f9e7bcb7ce4dc1eab00602912c96da43c29b4762dc376038",
+    "zh:71562d330d3f92d79b2952ffdda0dad167e952e46200c767dd30c6af8d7c0ed3",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:805f81ade06ff68fa8b908d31892eaed5c180ae031c77ad35f82cb7a74b97cf4",
+    "zh:8b6b3ebeaaa8e38dd04e56996abe80db9be6f4c1df75ac3cccc77642899bd464",
+    "zh:ad07750576b99248037b897de71113cc19b1a8d0bc235eb99173cc83d0de3b1b",
+    "zh:b9f1c3bfadb74068f5c205292badb0661e17ac05eb23bfe8bd809691e4583d0e",
+    "zh:cc4cbcd67414fefb111c1bf7ab0bc4beb8c0b553d01719ad17de9a047adff4d1",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/random" {
   version     = "3.6.2"
   constraints = "3.6.2"
@@ -61,5 +80,24 @@ provider "registry.terraform.io/hashicorp/random" {
     "zh:bb6297ce412c3c2fa9fec726114e5e0508dd2638cad6a0cb433194930c97a544",
     "zh:f83e925ed73ff8a5ef6e3608ad9225baa5376446349572c2449c0c0b3cf184b7",
     "zh:fbef0781cb64de76b1df1ca11078aecba7800d82fd4a956302734999cfd9a4af",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version = "4.0.6"
+  hashes = [
+    "h1:n3M50qfWfRSpQV9Pwcvuse03pEizqrmYEryxKky4so4=",
+    "zh:10de0d8af02f2e578101688fd334da3849f56ea91b0d9bd5b1f7a243417fdda8",
+    "zh:37fc01f8b2bc9d5b055dc3e78bfd1beb7c42cfb776a4c81106e19c8911366297",
+    "zh:4578ca03d1dd0b7f572d96bd03f744be24c726bfd282173d54b100fd221608bb",
+    "zh:6c475491d1250050765a91a493ef330adc24689e8837a0f07da5a0e1269e11c1",
+    "zh:81bde94d53cdababa5b376bbc6947668be4c45ab655de7aa2e8e4736dfd52509",
+    "zh:abdce260840b7b050c4e401d4f75c7a199fafe58a8b213947a258f75ac18b3e8",
+    "zh:b754cebfc5184873840f16a642a7c9ef78c34dc246a8ae29e056c79939963c7a",
+    "zh:c928b66086078f9917aef0eec15982f2e337914c5c4dbc31dd4741403db7eb18",
+    "zh:cded27bee5f24de6f2ee0cfd1df46a7f88e84aaffc2ecbf3ff7094160f193d50",
+    "zh:d65eb3867e8f69aaf1b8bb53bd637c99c6b649ba3db16ded50fa9a01076d1a27",
+    "zh:ecb0c8b528c7a619fa71852bb3fb5c151d47576c5aab2bf3af4db52588722eeb",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }

--- a/infra/README.md
+++ b/infra/README.md
@@ -49,13 +49,13 @@ The default multiplexer is `byobu`. Here is a [cheatsheet](https://gist.github.c
 To ingest the data in the Target Cluster:
 
 ```shell
-bash /ingest.sh
+bash /mnt/ingest.sh
 ```
 
 Alternatively, if you already have a snapshot and you want to restore it, do:
 
 ```shell
-bash /restore_snapshot.sh
+bash /mnt/restore_snapshot.sh
 ```
 
 ## Benchmark the queries
@@ -63,13 +63,13 @@ bash /restore_snapshot.sh
 - Pass `official` or `dev` to tag the run results
 
 ```shell
-bash /benchmark.sh [official|dev]
+bash /mnt/benchmark.sh [official|dev]
 ```
 
 ## Additional client options
 To specify additional client options use the `EXTRA_CLIENT_OPTIONS` environment variable:
 ```shell
-EXTRA_CLIENT_OPTIONS=timeout:240 bash /ingest.sh
+EXTRA_CLIENT_OPTIONS=timeout:240 bash /mnt/ingest.sh
 ```
 
 ## Get the results

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -40,9 +40,21 @@ provider "aws" {
   }
 }
 
+resource "tls_private_key" "ssh_key" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+# Save private key to a local file
+resource "local_file" "private_key" {
+  content         = tls_private_key.ssh_key.private_key_pem
+  filename        = "${path.module}/private_key-${md5(tls_private_key.ssh_key.public_key_openssh)}.pem"
+  file_permission = "0600"
+}
+
 resource "aws_key_pair" "ssh_key" {
   key_name   = "${terraform.workspace}-ssh-key"
-  public_key = file(var.ssh_pub_key)
+  public_key = tls_private_key.ssh_key.public_key_openssh
 }
 
 resource "aws_vpc" "vpc" {
@@ -165,7 +177,8 @@ module "es-cluster" {
   es_version            = var.es_version
   distribution_version  = var.distribution_version
   ssh_key_name          = aws_key_pair.ssh_key.key_name
-  ssh_priv_key          = var.ssh_priv_key
+  ssh_priv_key          = tls_private_key.ssh_key.private_key_openssh
+  ssh_pub_key           = tls_private_key.ssh_key.public_key_openssh
   security_groups       = [aws_security_group.allow_osb.id]
   subnet_id             = aws_subnet.subnet.id
   password              = random_password.cluster-password.result
@@ -202,7 +215,8 @@ module "os-cluster" {
   os_version            = var.os_version
   distribution_version  = var.distribution_version
   ssh_key_name          = aws_key_pair.ssh_key.key_name
-  ssh_priv_key          = var.ssh_priv_key
+  ssh_priv_key          = tls_private_key.ssh_key.private_key_openssh
+  ssh_pub_key           = tls_private_key.ssh_key.public_key_openssh
   security_groups       = [aws_security_group.allow_osb.id]
   subnet_id             = aws_subnet.subnet.id
   password              = random_password.cluster-password.result

--- a/infra/modules/elasticsearch/es-cluster.yaml
+++ b/infra/modules/elasticsearch/es-cluster.yaml
@@ -14,6 +14,10 @@ write_files:
     content: ${es_cluster_script}
     owner: root:root
     permissions: '0755'
+  - path: /ssh_pub_key
+    content: ${authorized_ssh_key}
+    owner: ubuntu:ubuntu
+    permissions: '0644'
 
 fs_setup:
   - label: None
@@ -33,4 +37,5 @@ bootcmd:
 runcmd:
   - [ sysctl, -p, /etc/sysctl.d/99-custom.conf ]
   - [ chown, -R, ubuntu:ubuntu, /mnt ]
+  - [ mv, /ssh_pub_key, /home/ubuntu/.ssh/authorized_keys ]
   - [ sudo, -u, ubuntu, /es_cluster.sh, ${es_password}, ${es_version}, ${es_snapshot_access_key}, ${es_snapshot_secret_key} ]

--- a/infra/modules/elasticsearch/es-load-generation.yaml
+++ b/infra/modules/elasticsearch/es-load-generation.yaml
@@ -25,31 +25,11 @@ write_files:
       ${big5_es_index_8}
     owner: root:root
     permissions: '0644'
-  - path: /benchmark.sh
+  - path: /id_rsa
     encoding: gz+b64
-    content: ${benchmark_script}
-    owner: root:root
-    permissions: '0755'
-  - path: /benchmark_single.sh
-    encoding: gz+b64
-    content: ${benchmark_single_script}
-    owner: root:root
-    permissions: '0755'
-  - path: /ingest.sh
-    encoding: gz+b64
-    content: ${ingest_script}
-    owner: root:root
-    permissions: '0755'
-  - path: /restore_snapshot.sh
-    encoding: gz+b64
-    content: ${restore_snapshot_script}
-    owner: root:root
-    permissions: '0755'
-  - path: /utils.sh
-    encoding: gz+b64
-    content: ${utils_script}
-    owner: root:root
-    permissions: '0755'
+    content: ${ssh_private_key}
+    owner: ubuntu:ubuntu
+    permissions: '0600'
 
 fs_setup:
   - label: None
@@ -78,7 +58,9 @@ packages:
 runcmd:
   - [ sysctl, -p, /etc/sysctl.d/99-custom.conf ]
   - [ chown, -R, ubuntu:ubuntu, /mnt ]
-  - [ sudo, -u, ubuntu, /load_generation.sh, https://${es_cluster}:9200, elastic, ${es_password}, ${distribution_version}, ${es_version}, "ES", ${instance_type}, ${cluster_instance_id}]
+  - [ mv, /id_rsa, /home/ubuntu/.ssh/id_rsa ]
+  - [ chown, ubuntu:ubuntu, /home/ubuntu/.ssh/id_rsa ]
+  - [ sudo, -u, ubuntu, /load_generation.sh, ${es_cluster}, elastic, ${es_password}, ${distribution_version}, ${es_version}, "ES", ${instance_type}, ${cluster_instance_id}]
   - [ sudo, -u, ubuntu, /fix_index.sh, https://${es_cluster}:9200, elastic, ${es_password} ]
   - [sed, -i, '/^env.name =/c\env.name = ${benchmark_environment}', /mnt/.benchmark/benchmark.ini]
   - [sed, -i, '/^datastore\./s/^/# /',  /mnt/.benchmark/benchmark.ini]

--- a/infra/modules/elasticsearch/main.tf
+++ b/infra/modules/elasticsearch/main.tf
@@ -28,6 +28,7 @@ resource "aws_instance" "target-cluster" {
 
       es_snapshot_access_key = var.snapshot_user_aws_access_key_id,
       es_snapshot_secret_key = var.snapshot_user_aws_secret_access_key,
+      authorized_ssh_key     = var.ssh_pub_key
     }
   )
   user_data_replace_on_change = true
@@ -72,53 +73,12 @@ resource "aws_instance" "load-generation" {
       datastore_password    = var.datastore_password
       instance_type         = var.instance_type
       cluster_instance_id   = aws_instance.target-cluster.id
-
-      ingest_script = yamlencode(
-        base64gzip(templatefile("${path.module}/../../scripts/ingest.sh",
-          {
-            workload         = var.workload
-            s3_bucket_name   = var.s3_bucket_name,
-            workload_params  = var.workload_params,
-            snapshot_version = var.snapshot_version,
-          }
-        ))
-      ),
-      restore_snapshot_script = yamlencode(
-        base64gzip(templatefile("${path.module}/../../scripts/restore_snapshot.sh",
-          {
-            workload         = var.workload
-            s3_bucket_name   = var.s3_bucket_name,
-            workload_params  = var.workload_params,
-            snapshot_version = var.snapshot_version,
-          }
-        ))
-      ),
-      benchmark_script = yamlencode(
-        base64gzip(templatefile("${path.module}/../../scripts/benchmark.sh",
-          {
-            workload        = var.workload
-            workload_params = var.workload_params,
-            test_procedure  = var.test_procedure,
-          }
-        ))
-      ),
-      benchmark_single_script = yamlencode(
-        base64gzip(templatefile("${path.module}/../../scripts/benchmark_single.sh",
-          {
-            workload        = var.workload
-            workload_params = var.workload_params,
-            test_procedure  = var.test_procedure,
-          }
-        ))
-      ),
       fix_index_script = yamlencode(base64gzip(templatefile("${path.module}/fix_index.sh",
         {
           workload = var.workload,
         }
       ))),
-      utils_script = yamlencode(
-        base64gzip(file("${path.module}/../../scripts/utils.sh"))
-      ),
+      ssh_private_key = base64gzip(var.ssh_priv_key)
     }
   )
   user_data_replace_on_change = true
@@ -134,8 +94,59 @@ resource "aws_instance" "load-generation" {
   connection {
     type        = "ssh"
     user        = "ubuntu"
-    private_key = file(var.ssh_priv_key)
+    private_key = var.ssh_priv_key
     host        = self.public_ip
+  }
+
+  provisioner "file" {
+    content = templatefile("${path.module}/../../scripts/ingest.sh",
+      {
+        workload         = var.workload,
+        workload_params  = var.workload_params,
+        s3_bucket_name   = var.s3_bucket_name,
+        snapshot_version = var.snapshot_version,
+      }
+    )
+    destination = "/mnt/ingest.sh"
+  }
+
+  provisioner "file" {
+    content = templatefile("${path.module}/../../scripts/restore_snapshot.sh",
+      {
+        workload         = var.workload
+        s3_bucket_name   = var.s3_bucket_name,
+        workload_params  = var.workload_params,
+        snapshot_version = var.snapshot_version,
+      }
+    )
+    destination = "/mnt/restore_snapshot.sh"
+  }
+
+  provisioner "file" {
+    content = templatefile("${path.module}/../../scripts/benchmark.sh",
+      {
+        workload        = var.workload
+        workload_params = var.workload_params,
+        test_procedure  = var.test_procedure,
+      }
+    )
+    destination = "/mnt/benchmark.sh"
+  }
+
+  provisioner "file" {
+    content = templatefile("${path.module}/../../scripts/benchmark_single.sh",
+      {
+        workload        = var.workload
+        workload_params = var.workload_params,
+        test_procedure  = var.test_procedure,
+      }
+    )
+    destination = "/mnt/benchmark_single.sh"
+  }
+
+  provisioner "file" {
+    source      = "${path.module}/../../scripts/utils.sh"
+    destination = "/mnt/utils.sh"
   }
 
   private_dns_name_options {

--- a/infra/modules/elasticsearch/variables.tf
+++ b/infra/modules/elasticsearch/variables.tf
@@ -26,7 +26,12 @@ variable "ssh_key_name" {
 }
 
 variable "ssh_priv_key" {
-  description = "Path to the SSH Private Key"
+  description = "SSH Private Key"
+  type        = string
+}
+
+variable "ssh_pub_key" {
+  description = "SSH Pub Key"
   type        = string
 }
 

--- a/infra/modules/opensearch/main.tf
+++ b/infra/modules/opensearch/main.tf
@@ -27,6 +27,7 @@ resource "aws_instance" "target-cluster" {
       os_version             = var.os_version,
       os_snapshot_access_key = var.snapshot_user_aws_access_key_id,
       os_snapshot_secret_key = var.snapshot_user_aws_secret_access_key,
+      authorized_ssh_key     = var.ssh_pub_key,
     }
   )
   user_data_replace_on_change = true
@@ -70,48 +71,7 @@ resource "aws_instance" "load-generation" {
       datastore_password    = var.datastore_password
       instance_type         = var.instance_type
       cluster_instance_id   = aws_instance.target-cluster.id
-
-      ingest_script = yamlencode(
-        base64gzip(templatefile("${path.module}/../../scripts/ingest.sh",
-          {
-            workload         = var.workload,
-            workload_params  = var.workload_params,
-            s3_bucket_name   = var.s3_bucket_name,
-            snapshot_version = var.snapshot_version,
-          }
-        ))
-      ),
-      restore_snapshot_script = yamlencode(
-        base64gzip(templatefile("${path.module}/../../scripts/restore_snapshot.sh",
-          {
-            workload         = var.workload
-            s3_bucket_name   = var.s3_bucket_name,
-            workload_params  = var.workload_params,
-            snapshot_version = var.snapshot_version,
-          }
-        ))
-      ),
-      benchmark_script = yamlencode(
-        base64gzip(templatefile("${path.module}/../../scripts/benchmark.sh",
-          {
-            workload        = var.workload
-            workload_params = var.workload_params,
-            test_procedure  = var.test_procedure,
-          }
-        ))
-      ),
-      benchmark_single_script = yamlencode(
-        base64gzip(templatefile("${path.module}/../../scripts/benchmark_single.sh",
-          {
-            workload        = var.workload
-            workload_params = var.workload_params,
-            test_procedure  = var.test_procedure,
-          }
-        ))
-      ),
-      utils_script = yamlencode(
-        base64gzip(file("${path.module}/../../scripts/utils.sh"))
-      ),
+      ssh_private_key       = base64gzip(var.ssh_priv_key)
     }
   )
   user_data_replace_on_change = true
@@ -127,12 +87,63 @@ resource "aws_instance" "load-generation" {
   connection {
     type        = "ssh"
     user        = "ubuntu"
-    private_key = file(var.ssh_priv_key)
+    private_key = var.ssh_priv_key
     host        = self.public_ip
   }
 
   private_dns_name_options {
     hostname_type = "resource-name"
+  }
+
+  provisioner "file" {
+    content = templatefile("${path.module}/../../scripts/ingest.sh",
+      {
+        workload         = var.workload,
+        workload_params  = var.workload_params,
+        s3_bucket_name   = var.s3_bucket_name,
+        snapshot_version = var.snapshot_version,
+      }
+    )
+    destination = "/mnt/ingest.sh"
+  }
+
+  provisioner "file" {
+    content = templatefile("${path.module}/../../scripts/restore_snapshot.sh",
+      {
+        workload         = var.workload
+        s3_bucket_name   = var.s3_bucket_name,
+        workload_params  = var.workload_params,
+        snapshot_version = var.snapshot_version,
+      }
+    )
+    destination = "/mnt/restore_snapshot.sh"
+  }
+
+  provisioner "file" {
+    content = templatefile("${path.module}/../../scripts/benchmark.sh",
+      {
+        workload        = var.workload
+        workload_params = var.workload_params,
+        test_procedure  = var.test_procedure,
+      }
+    )
+    destination = "/mnt/benchmark.sh"
+  }
+
+  provisioner "file" {
+    content = templatefile("${path.module}/../../scripts/benchmark_single.sh",
+      {
+        workload        = var.workload
+        workload_params = var.workload_params,
+        test_procedure  = var.test_procedure,
+      }
+    )
+    destination = "/mnt/benchmark_single.sh"
+  }
+
+  provisioner "file" {
+    source      = "${path.module}/../../scripts/utils.sh"
+    destination = "/mnt/utils.sh"
   }
 
   tags = {

--- a/infra/modules/opensearch/os-cluster.yaml
+++ b/infra/modules/opensearch/os-cluster.yaml
@@ -14,6 +14,10 @@ write_files:
     content: ${os_cluster_script}
     owner: root:root
     permissions: '0755'
+  - path: /ssh_pub_key
+    content: ${authorized_ssh_key}
+    owner: ubuntu:ubuntu
+    permissions: '0644'
 
 fs_setup:
   - label: None
@@ -33,4 +37,5 @@ bootcmd:
 runcmd:
   - [ sysctl, -p, /etc/sysctl.d/99-custom.conf ]
   - [ chown, -R, ubuntu:ubuntu, /mnt ]
+  - [ mv, /ssh_pub_key, /home/ubuntu/.ssh/authorized_keys ]
   - [ sudo, -u, ubuntu, /os_cluster.sh, ${os_password}, ${os_version}, ${os_snapshot_access_key}, ${os_snapshot_secret_key}  ]

--- a/infra/modules/opensearch/os-load-generation.yaml
+++ b/infra/modules/opensearch/os-load-generation.yaml
@@ -14,31 +14,11 @@ write_files:
     content: ${load_script}
     owner: root:root
     permissions: '0755'
-  - path: /benchmark.sh
+  - path: /id_rsa
     encoding: gz+b64
-    content: ${benchmark_script}
-    owner: root:root
-    permissions: '0755'
-  - path: /benchmark_single.sh
-    encoding: gz+b64
-    content: ${benchmark_single_script}
-    owner: root:root
-    permissions: '0755'
-  - path: /ingest.sh
-    encoding: gz+b64
-    content: ${ingest_script}
-    owner: root:root
-    permissions: '0755'
-  - path: /restore_snapshot.sh
-    encoding: gz+b64
-    content: ${restore_snapshot_script}
-    owner: root:root
-    permissions: '0755'
-  - path: /utils.sh
-    encoding: gz+b64
-    content: ${utils_script}
-    owner: root:root
-    permissions: '0755'
+    content: ${ssh_private_key}
+    owner: ubuntu:ubuntu
+    permissions: '0600'
 
 fs_setup:
   - label: None
@@ -67,7 +47,9 @@ packages:
 runcmd:
   - [ sysctl, -p, /etc/sysctl.d/99-custom.conf ]
   - [ chown, -R, ubuntu:ubuntu, /mnt ]
-  - [ sudo, -u, ubuntu, /load_generation.sh, https://${os_cluster}:9200, admin, ${os_password}, ${distribution_version}, ${os_version}, "OS", ${instance_type}, ${cluster_instance_id}]
+  - [ mv, /id_rsa, /home/ubuntu/.ssh/id_rsa ]
+  - [ chown, ubuntu:ubuntu, /home/ubuntu/.ssh/id_rsa ]
+  - [ sudo, -u, ubuntu, /load_generation.sh, ${os_cluster}, admin, ${os_password}, ${distribution_version}, ${os_version}, "OS", ${instance_type}, ${cluster_instance_id}]
   - [sed, -i, '/^env.name =/c\env.name = ${benchmark_environment}', /mnt/.benchmark/benchmark.ini]
   - [sed, -i, '/^datastore\./s/^/# /',  /mnt/.benchmark/benchmark.ini]
   - |

--- a/infra/modules/opensearch/variables.tf
+++ b/infra/modules/opensearch/variables.tf
@@ -26,7 +26,12 @@ variable "ssh_key_name" {
 }
 
 variable "ssh_priv_key" {
-  description = "Path to the SSH Private Key"
+  description = "SSH Private Key"
+  type        = string
+}
+
+variable "ssh_pub_key" {
+  description = "SSH Pub Key"
   type        = string
 }
 

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -14,3 +14,7 @@ output "cluster-password" {
 output "snapshot-version" {
   value = data.external.latest_snapshot_version.result.latest_version
 }
+
+output "ssh_private_key_file" {
+  value = local_file.private_key.filename
+}

--- a/infra/scripts/benchmark.sh
+++ b/infra/scripts/benchmark.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source /utils.sh
+source /mnt/utils.sh
 
 if [ $# -ne 1 ]; then
     echo "Usage: bash benchmark.sh <run-type>"
@@ -57,11 +57,19 @@ fi
 GROUP_USER_TAGS="run-group:$RUN_GROUP_ID,engine-type:$ENGINE_TYPE,arch:$(arch),instance-type:$INSTANCE_TYPE,aws-user-id:$AWS_USERID,aws-loadgen-instance-id:$AWS_LOADGEN_INSTANCE_ID"
 GROUP_USER_TAGS+=",cluster-version:$CLUSTER_VERSION,workload-distribution-version:$DISTRIBUTION_VERSION,shard-count:$SHARD_COUNT,replica-count:$REPLICA_COUNT"
 GROUP_USER_TAGS+=",run-type:$RUN_TYPE,aws-cluster-instance-id:$CLUSTER_INSTANCE_ID"
-GROUP_USER_TAGS+=",cpu-model-name:$(lscpu | grep "Model name" | cut -d':' -f2 | xargs)"
-GROUP_USER_TAGS+=",cpu-cache-l1d:$(lscpu | grep "L1d" | cut -d':' -f2 | xargs)"
-GROUP_USER_TAGS+=",cpu-cache-l1i:$(lscpu | grep "L1i" | cut -d':' -f2 | xargs)"
-GROUP_USER_TAGS+=",cpu-cache-l2:$(lscpu | grep "L2" | cut -d':' -f2 | xargs)"
-GROUP_USER_TAGS+=",cpu-cache-l3:$(lscpu | grep "L3" | cut -d':' -f2 | xargs)"
+
+GROUP_USER_TAGS+=",lg-cpu-model-name:$(lscpu | grep "Model name" | cut -d':' -f2 | xargs)"
+GROUP_USER_TAGS+=",lg-cpu-cache-l1d:$(lscpu | grep "L1d" | cut -d':' -f2 | xargs)"
+GROUP_USER_TAGS+=",lg-cpu-cache-l1i:$(lscpu | grep "L1i" | cut -d':' -f2 | xargs)"
+GROUP_USER_TAGS+=",lg-cpu-cache-l2:$(lscpu | grep "L2" | cut -d':' -f2 | xargs)"
+GROUP_USER_TAGS+=",lg-cpu-cache-l3:$(lscpu | grep "L3" | cut -d':' -f2 | xargs)"
+
+TC_CMD="ssh -o StrictHostKeyChecking=no ubuntu@${CLUSTER_HOST_SSH} -- "
+GROUP_USER_TAGS+=",tc-cpu-model-name:$($TC_CMD 'lscpu | grep "Model name" | cut -d':' -f2 | xargs')"
+GROUP_USER_TAGS+=",tc-cpu-cache-l1d:$($TC_CMD 'lscpu | grep "L1d" | cut -d':' -f2 | xargs')"
+GROUP_USER_TAGS+=",tc-cpu-cache-l1i:$($TC_CMD 'lscpu | grep "L1i" | cut -d':' -f2 | xargs')"
+GROUP_USER_TAGS+=",tc-cpu-cache-l2:$($TC_CMD 'lscpu | grep "L2" | cut -d':' -f2 | xargs')"
+GROUP_USER_TAGS+=",tc-cpu-cache-l3:$($TC_CMD 'lscpu | grep "L3" | cut -d':' -f2 | xargs')"
 
 REPOSITORY_SET=$(curl -sku "$CLUSTER_USER:$CLUSTER_PASSWORD" -X GET "$CLUSTER_HOST/_cluster/state/metadata" | jq --raw-output '.metadata | has("repositories") and .repositories != null')
 if [ "$REPOSITORY_SET" == "true" ]; then

--- a/infra/scripts/benchmark_single.sh
+++ b/infra/scripts/benchmark_single.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source /utils.sh
+source /mnt/utils.sh
 
 if [ $# -ne 2 ]; then
     echo "Usage: bash benchmark.sh <run-type> <run-id>"
@@ -58,11 +58,19 @@ fi
 GROUP_USER_TAGS="run-group:$RUN_GROUP_ID,engine-type:$ENGINE_TYPE,arch:$(arch),instance-type:$INSTANCE_TYPE,aws-user-id:$AWS_USERID,aws-loadgen-instance-id:$AWS_LOADGEN_INSTANCE_ID"
 GROUP_USER_TAGS+=",cluster-version:$CLUSTER_VERSION,workload-distribution-version:$DISTRIBUTION_VERSION,shard-count:$SHARD_COUNT,replica-count:$REPLICA_COUNT"
 GROUP_USER_TAGS+=",run-type:$RUN_TYPE,aws-cluster-instance-id:$CLUSTER_INSTANCE_ID"
-GROUP_USER_TAGS+=",cpu-model-name:$(lscpu | grep "Model name" | cut -d':' -f2 | xargs)"
-GROUP_USER_TAGS+=",cpu-cache-l1d:$(lscpu | grep "L1d" | cut -d':' -f2 | xargs)"
-GROUP_USER_TAGS+=",cpu-cache-l1i:$(lscpu | grep "L1i" | cut -d':' -f2 | xargs)"
-GROUP_USER_TAGS+=",cpu-cache-l2:$(lscpu | grep "L2" | cut -d':' -f2 | xargs)"
-GROUP_USER_TAGS+=",cpu-cache-l3:$(lscpu | grep "L3" | cut -d':' -f2 | xargs)"
+
+GROUP_USER_TAGS+=",lg-cpu-model-name:$(lscpu | grep "Model name" | cut -d':' -f2 | xargs)"
+GROUP_USER_TAGS+=",lg-cpu-cache-l1d:$(lscpu | grep "L1d" | cut -d':' -f2 | xargs)"
+GROUP_USER_TAGS+=",lg-cpu-cache-l1i:$(lscpu | grep "L1i" | cut -d':' -f2 | xargs)"
+GROUP_USER_TAGS+=",lg-cpu-cache-l2:$(lscpu | grep "L2" | cut -d':' -f2 | xargs)"
+GROUP_USER_TAGS+=",lg-cpu-cache-l3:$(lscpu | grep "L3" | cut -d':' -f2 | xargs)"
+
+TC_CMD="ssh -o StrictHostKeyChecking=no ubuntu@${CLUSTER_HOST_SSH} -- "
+GROUP_USER_TAGS+=",tc-cpu-model-name:$($TC_CMD 'lscpu | grep "Model name" | cut -d':' -f2 | xargs')"
+GROUP_USER_TAGS+=",tc-cpu-cache-l1d:$($TC_CMD 'lscpu | grep "L1d" | cut -d':' -f2 | xargs')"
+GROUP_USER_TAGS+=",tc-cpu-cache-l1i:$($TC_CMD 'lscpu | grep "L1i" | cut -d':' -f2 | xargs')"
+GROUP_USER_TAGS+=",tc-cpu-cache-l2:$($TC_CMD 'lscpu | grep "L2" | cut -d':' -f2 | xargs')"
+GROUP_USER_TAGS+=",tc-cpu-cache-l3:$($TC_CMD 'lscpu | grep "L3" | cut -d':' -f2 | xargs')"
 
 set -x
 

--- a/infra/scripts/ingest.sh
+++ b/infra/scripts/ingest.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source /utils.sh
+source /mnt/utils.sh
 
 if [ -z "$CLUSTER_HOST" ] || [ -z "$CLUSTER_USER" ] || [ -z "$CLUSTER_PASSWORD" ] || [ -z "$DISTRIBUTION_VERSION" ]; then
     echo "Please set the CLUSTER_HOST, CLUSTER_USER, CLUSTER_PASSWORD and DISTRIBUTION_VERSION environment variables"
@@ -47,7 +47,7 @@ register_snapshot_repo \
 
 response=$(curl -s -ku $CLUSTER_USER:$CLUSTER_PASSWORD -X GET "$CLUSTER_HOST/_snapshot/$SNAPSHOT_S3_BUCKET/$SNAPSHOT_NAME")
 if [[ $(echo "$response" | jq -r '.snapshots | length') -gt 0 ]] && [ -z "$FORCE_INGESTION" ]; then
-    echo "There's a snapshot already. Use /restore_snapshot.sh to restore it."
+    echo "There's a snapshot already. Use /mnt/restore_snapshot.sh to restore it."
     echo "If you want to recreate the snapshot, set FORCE_INGESTION=true."
     exit 1
 fi
@@ -99,4 +99,4 @@ echo "$response" | jq -e '.error' > /dev/null && {
 }
 echo "Snapshot done"
 
-/restore_snapshot.sh
+/mnt/restore_snapshot.sh

--- a/infra/scripts/load_generation.sh
+++ b/infra/scripts/load_generation.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
-source /utils.sh
+source /mnt/utils.sh
 
 # Get script directory
-CLUSTER_HOST=$1
+CLUSTER_HOST_SSH=$1
+CLUSTER_HOST=https://$CLUSTER_HOST_SSH:9200
 CLUSTER_USER=$2
 CLUSTER_PASSWORD=$3
 DISTRIBUTION_VERSION=$4
@@ -29,6 +30,7 @@ export BENCHMARK_HOME=/mnt
 echo 'export PATH=$PATH:~/.local/bin' >> ~/.bashrc
 echo 'export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64/' >> ~/.bashrc
 echo 'export BENCHMARK_HOME=/mnt' >> ~/.bashrc
+echo "export CLUSTER_HOST_SSH=$CLUSTER_HOST_SSH" >> ~/.bashrc
 echo "export CLUSTER_HOST=$CLUSTER_HOST" >> ~/.bashrc
 echo "export CLUSTER_USER=$CLUSTER_USER" >> ~/.bashrc
 echo "export DISTRIBUTION_VERSION=$DISTRIBUTION_VERSION" >> ~/.bashrc

--- a/infra/scripts/restore_snapshot.sh
+++ b/infra/scripts/restore_snapshot.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source /utils.sh
+source /mnt/utils.sh
 
 # This comes from the user `terraform.tfvars` configuration file
 # shellcheck disable=SC2154

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,15 +1,3 @@
-variable "ssh_priv_key" {
-  description = "Path to the SSH Private Key"
-  type        = string
-  default     = "~/.ssh/id_rsa"
-}
-
-variable "ssh_pub_key" {
-  description = "Path to the SSH Public Key"
-  type        = string
-  default     = "~/.ssh/id_rsa.pub"
-}
-
 variable "aws_region" {
   description = "AWS region used for the deployment"
   type        = string


### PR DESCRIPTION
- tags the target-cluster CPU info (and not the load-generation host ones as by mistake we were doing)
- i had to use ssh to run commands from the load-generation host into the target-cluster node, but i didn't want to upload one's private ssh key so this PR generates a new temporary SSH key that is saved in the cwd and is used to connect to the hosts
- unfortunately i hit again the limit of the user-data we pass when creating the EC2 instances, so... I decided to split some scripts in the `provisioner` blocks. The way i split them is that files that are not needed to setup the host are placed in the `provisioner` block. For example, `/ingest.sh` is run manually by the user *after* the machine is already setup, so there's no need to pass it when the machine is configured but it can be loaded separately after that with the `provisioner` block.
- due to permissions issues with the new `provisioner` blocks, files were moved in the `/mnt` directory instead of `/`.