### PR TITLE
ci: add snapshot_version input to all-ingest

### DIFF
--- a/.github/workflows/all-ingest.yml
+++ b/.github/workflows/all-ingest.yml
@@ -32,6 +32,11 @@ on:
         required: false
         type: string
         default: 8.15.0
+      snapshot_version:
+        description: 'Snapshot version (`new` or `latest`)'
+        required: true
+        type: string
+        default: 'latest'
       os_versions:
         description: 'OpenSearch versions (comma separated)'
         required: false
@@ -88,6 +93,7 @@ jobs:
       es_version: ${{ matrix.es_version }}
       os_version: ${{ matrix.os_version }}
       aws_region: ${{ inputs.aws_region || 'ca-central-1' }}
+      snapshot_version: ${{ inputs.snapshot_version }}
       # assumes the only possible event is workflow_dispatch
       ci_tag: 'manual'
     secrets:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -66,6 +66,11 @@ on:
         description: 'Tag describing CI run'
         required: true
         type: string
+      snapshot_version:
+        description: 'Snapshot version (`new` or `latest`)'
+        required: false
+        type: string
+        default: 'latest'
     secrets:
       AWS_ACCESS_KEY_ID:
         required: true
@@ -102,6 +107,7 @@ env:
   TF_VAR_es_version: ${{ inputs.es_version }}
   TF_VAR_os_version: ${{ inputs.os_version }}
   TF_VAR_distribution_version: ${{ inputs.os_version }}
+  TF_VAR_snapshot_version: ${{ inputs.snapshot_version }}
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   SSH_OPTIONS: -o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=10


### PR DESCRIPTION
Allow to generate new snapshot versions from CI.